### PR TITLE
Add required OpenCV find package for use with Caffe.  The change to n…

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ if (JSONCPP_FOUND)
     target_link_libraries(gbdxm ${JSONCPP_LIBRARY})
 endif()
 
+#This find_package call for OpenCV is necessary according to the CaffeConfig.cmake file.
+find_package(OpenCV REQUIRED)
 find_package(Caffe REQUIRED)
 if (Caffe_FOUND)
     if (DEEPCORE_STATIC)


### PR DESCRIPTION
…v-caffe requires it to be in the Cmake file prior to finding Caffe.